### PR TITLE
fix: evaluateSteps after each submodule

### DIFF
--- a/pkg/iac/scanners/terraform/parser/evaluator.go
+++ b/pkg/iac/scanners/terraform/parser/evaluator.go
@@ -139,8 +139,6 @@ func (e *evaluator) EvaluateAll(ctx context.Context) (terraform.Modules, map[str
 	e.blocks = e.expandBlocks(e.blocks)
 	e.blocks = e.expandBlocks(e.blocks)
 
-	parseDuration += time.Since(start)
-
 	e.debug.Log("Starting submodule evaluation...")
 	submodules := e.loadSubmodules(ctx)
 
@@ -163,9 +161,6 @@ func (e *evaluator) EvaluateAll(ctx context.Context) (terraform.Modules, map[str
 
 	e.debug.Log("Finished processing %d submodule(s).", len(modules))
 
-	e.debug.Log("Starting post-submodule evaluation...")
-	e.evaluateSteps()
-
 	e.debug.Log("Module evaluation complete.")
 	parseDuration += time.Since(start)
 	rootModule := terraform.NewModule(e.projectRootPath, e.modulePath, e.blocks, e.ignores)
@@ -176,7 +171,7 @@ type submodule struct {
 	definition *ModuleDefinition
 	eval       *evaluator
 	modules    terraform.Modules
-	lastState  cty.Value
+	lastState  map[string]cty.Value
 	fsMap      map[string]fs.FS
 }
 
@@ -203,19 +198,26 @@ func (e *evaluator) loadSubmodules(ctx context.Context) []*submodule {
 }
 
 func (e *evaluator) evaluateSubmodule(ctx context.Context, sm *submodule) bool {
-	sm.eval.inputVars = sm.definition.inputVars()
+	inputVars := sm.definition.inputVars()
+	if len(sm.modules) > 0 {
+		if reflect.DeepEqual(inputVars, sm.lastState) {
+			e.debug.Log("Submodule %s inputs unchanged", sm.definition.Name)
+			return false
+		}
+	}
+
+	e.debug.Log("Evaluating submodule %s", sm.definition.Name)
+	sm.eval.inputVars = inputVars
 	sm.modules, sm.fsMap, _ = sm.eval.EvaluateAll(ctx)
 	outputs := sm.eval.exportOutputs()
 
-	if reflect.DeepEqual(outputs, sm.lastState) {
-		e.debug.Log("Submodule %s outputs unchanged", sm.definition.Name)
-		return false
-	}
-	e.debug.Log("Submodule %s outputs changed", sm.definition.Name)
-
+	// lastState needs to be captured after applying outputs – so that they
+	// don't get treated as changes – but before running post-submodule
+	// evaluation, so that changes from that can trigger re-evaluations of
+	// the submodule if/when they feed back into inputs.
 	e.ctx.Set(outputs, "module", sm.definition.Name)
-	sm.lastState = outputs
-
+	sm.lastState = sm.definition.inputVars()
+	e.evaluateSteps()
 	return true
 }
 

--- a/pkg/iac/scanners/terraform/parser/evaluator.go
+++ b/pkg/iac/scanners/terraform/parser/evaluator.go
@@ -153,6 +153,9 @@ func (e *evaluator) EvaluateAll(ctx context.Context) (terraform.Modules, map[str
 		}
 	}
 
+	e.debug.Log("Starting post-submodule evaluation...")
+	e.evaluateSteps()
+
 	var modules terraform.Modules
 	for _, sm := range submodules {
 		modules = append(modules, sm.modules...)

--- a/pkg/iac/scanners/terraform/parser/parser_test.go
+++ b/pkg/iac/scanners/terraform/parser/parser_test.go
@@ -1571,12 +1571,18 @@ func TestCyclicModules(t *testing.T) {
 		"main.tf": `
 module "module2" {
 	source = "./modules/foo"
-	test_var = module.module1.test_out
+	test_var = passthru.handover.from_1
+}
+
+// Demonstrates need for evaluateSteps between submodule evaluations.
+resource "passthru" "handover" {
+	from_1 = module.module1.test_out
+	from_2 = module.module2.test_out
 }
 
 module "module1" {
 	source = "./modules/bar"
-	test_var = module.module2.test_out
+	test_var = passthru.handover.from_2
 }
 `,
 		"modules/foo/main.tf": `


### PR DESCRIPTION
## Description

- does post-submodule evaluation after each submodule, to handle indirect dependencies (with test)
- bases re-evaluation decision on whether input state has changed (because output state is handled by the above)
- no longer double-counts the initial `evaluateSteps` and `expandBlocks`es in `parseDuration`

## Checklist
- [x] I've read the [guidelines for contributing](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/) to this repository.
- [x] I've followed the [conventions](https://aquasecurity.github.io/trivy/latest/community/contribute/pr/#title) in the PR title.
- [x] I've added tests that prove my fix is effective or that my feature works.
- [ ] I've updated the [documentation](https://github.com/aquasecurity/trivy/blob/main/docs) with the relevant information (if needed).
- [ ] I've added usage information (if the PR introduces new options)
- [ ] I've included a "before" and "after" example to the description (if the PR is a user interface change).
